### PR TITLE
Disable MarkupStyle.Link when inserting a whitespace at the end of link.

### DIFF
--- a/hyphen/src/commonMain/kotlin/com/denser/hyphen/state/HyphenTextState.kt
+++ b/hyphen/src/commonMain/kotlin/com/denser/hyphen/state/HyphenTextState.kt
@@ -1,5 +1,6 @@
 package com.denser.hyphen.state
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.text.input.TextFieldBuffer
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.insert
@@ -180,6 +181,7 @@ class HyphenTextState(
      * @param buffer The mutable buffer provided by the input transformation, representing
      *   the text state after the user's latest edit.
      */
+    @OptIn(ExperimentalFoundationApi::class)
     fun processInput(buffer: TextFieldBuffer) {
         if (isUndoingOrRedoing) return
 
@@ -220,13 +222,23 @@ class HyphenTextState(
             buffer.asCharSequence().substring(start, buffer.selection.start).contains('\n')
         } else false
 
+        val isWhitespaceInsertion = (0 until buffer.changes.changeCount).any { i ->
+            val range = buffer.changes.getRange(i)
+            (range.start until range.end).any { buffer.asCharSequence()[it].isWhitespace() }
+        }
+
         val availableInlineStyles = (StyleSets.allInline + _spans.map { it.style }.filterIsInstance<MarkupStyle.Link>()).distinct()
         val activeInlineStyles = availableInlineStyles.filter { style ->
-            val hasStyleAtCursor = if (isNewlineInsertion) {
-                val (selStart, _) = resolvedSelection()
-                _spans.any { it.style == style && selStart > it.start && selStart < it.end }
-            } else {
-                hasStyle(style)
+            val hasStyleAtCursor = when {
+                isNewlineInsertion -> {
+                    val (selStart, _) = resolvedSelection()
+                    _spans.any { it.style == style && selStart > it.start && selStart < it.end }
+                }
+                style is MarkupStyle.Link && isWhitespaceInsertion -> {
+                    val (selStart, _) = resolvedSelection()
+                    _spans.any { it.style == style && selStart > it.start && selStart < it.end }
+                }
+                else -> hasStyle(style)
             }
             hasStyleAtCursor && (style !in StyleSets.allHeadings || pendingOverrides[style] == true)
         }

--- a/hyphen/src/commonTest/kotlin/com/denser/hyphen/state/HyphenTextStateTest.kt
+++ b/hyphen/src/commonTest/kotlin/com/denser/hyphen/state/HyphenTextStateTest.kt
@@ -177,4 +177,60 @@ class HyphenTextStateTest {
         // 2. Serialize exact substring (preserves span formatting)
         assertEquals("**Hello**", state.toMarkdown(0, 5))
     }
+
+    @Test
+    fun `link style should not expand after space at the end`() {
+        val state = HyphenTextState("google")
+        state.isFocused = true
+        state.select(0, 6)
+        state.toggleStyle(MarkupStyle.Link("https://google.com"))
+
+        // Ensure link is created
+        assertEquals(1, state.spans.size)
+        assertTrue(state.spans[0].style is MarkupStyle.Link)
+        assertEquals(0, state.spans[0].start)
+        assertEquals(6, state.spans[0].end)
+
+        // Move cursor to end
+        state.select(6)
+
+        // Type a space
+        state.textFieldState.edit {
+            replace(6, 6, " ")
+            selection = TextRange(7)
+            state.processInput(this)
+        }
+
+        // Verify link has NOT expanded
+        val linkSpan = state.spans.find { it.style is MarkupStyle.Link }
+        assertEquals(0, linkSpan?.start)
+        assertEquals(6, linkSpan?.end) // Should still be 6
+    }
+
+    @Test
+    fun `link style should not expand when replacing suffix with space`() {
+        // Test case for the fix: rawLengthDifference <= 0 but whitespace inserted
+        val state = HyphenTextState("googleX")
+        state.isFocused = true
+        state.select(0, 6) // Link is "google"
+        state.toggleStyle(MarkupStyle.Link("https://google.com"))
+
+        // Select the "X" (index 6 to 7)
+        state.select(6, 7)
+
+        // Replace "X" with a space " "
+        // previousText: "googleX" (len 7)
+        // newText:      "google " (len 7)
+        // rawLengthDifference = 0
+        state.textFieldState.edit {
+            replace(6, 7, " ")
+            selection = TextRange(7)
+            state.processInput(this)
+        }
+
+        // Verify link has NOT expanded to include the space
+        val linkSpan = state.spans.find { it.style is MarkupStyle.Link }
+        assertEquals(0, linkSpan?.start)
+        assertEquals(6, linkSpan?.end) // Should still be 6
+    }
 }


### PR DESCRIPTION
Implement functionality to disable MarkupStyle.Link when inserting a whitespace at the end of the link. 
This improves the UX of adding a Link in the editor: inserting a link happens through a dialog so it makes sense to finish editing it after pressing space on the keyboard. User can always update the link by selecting the link and just adjusting it via the dialog.