### PR TITLE
feat: Styled Blockquote

### DIFF
--- a/hyphen/src/commonMain/kotlin/com/denser/hyphen/markdown/MarkdownConstants.kt
+++ b/hyphen/src/commonMain/kotlin/com/denser/hyphen/markdown/MarkdownConstants.kt
@@ -30,31 +30,31 @@ internal object MarkdownConstants {
 
     // -, *, or • at line start
     val BULLET_LIST_REGEX = Regex(
-        pattern = """^[\-*•] (.*?)$""",
+        pattern = """^[\-*•][ \u00A0](.*?)$""",
         option = RegexOption.MULTILINE
     )
 
     // 1. at line start
     val ORDERED_LIST_REGEX = Regex(
-        pattern = """^\d+\. (.*?)$""",
+        pattern = """^\d+\.[ \u00A0](.*?)$""",
         option = RegexOption.MULTILINE
     )
 
-    // > or ┃ at line start
+    // > at line start
     val BLOCKQUOTE_REGEX = Regex(
-        pattern = """^[>┃] (.*?)$""",
+        pattern = """^>[ \u00A0](.*?)$""",
         option = RegexOption.MULTILINE
     )
 
     // - [ ] or * [ ] at line start
     val CHECKBOX_UNCHECKED_REGEX = Regex(
-        pattern = """^[\-*] \[\s\] (.*?)$""",
+        pattern = """^[\-*][ \u00A0]\[\s\][ \u00A0](.*?)$""",
         option = RegexOption.MULTILINE
     )
 
     // - [x] or * [X] at line start
     val CHECKBOX_CHECKED_REGEX = Regex(
-        pattern = """^[\-*] \[[xX]\] (.*?)$""",
+        pattern = """^[\-*][ \u00A0]\[[xX]\][ \u00A0](.*?)$""",
         option = RegexOption.MULTILINE
     )
 

--- a/hyphen/src/commonMain/kotlin/com/denser/hyphen/ui/HyphenBasicTextEditor.kt
+++ b/hyphen/src/commonMain/kotlin/com/denser/hyphen/ui/HyphenBasicTextEditor.kt
@@ -2,6 +2,7 @@ package com.denser.hyphen.ui
 
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
@@ -15,13 +16,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.platform.LocalClipboard
-import com.denser.hyphen.ui.LocalHyphenRawClipboard
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.denser.hyphen.model.MarkupStyle
 import com.denser.hyphen.state.HyphenTextState
@@ -35,6 +36,7 @@ import com.denser.hyphen.ui.internal.applyMarkdownStyles
 import com.denser.hyphen.ui.internal.handleHardwareKeyEvent
 import com.denser.hyphen.ui.internal.processMarkdownInput
 import com.denser.hyphen.ui.internal.rememberMarkdownClipboard
+import com.denser.hyphen.ui.internal.drawBlockquotes
 
 /**
  * A markdown-aware text editor that provides rich inline formatting, block-level styles,
@@ -156,7 +158,9 @@ fun HyphenBasicTextEditor(
                 .onPreviewKeyEvent { event -> handleHardwareKeyEvent(event, state) }
                 .onFocusChanged { focusState ->
                     state.isFocused = focusState.isFocused
-                },
+                }
+                .drawBlockquotes(state, styleConfig, { textLayoutResult }, scrollState)
+                .padding(horizontal = 8.dp),
             enabled = enabled,
             readOnly = readOnly,
             textStyle = textStyle,

--- a/hyphen/src/commonMain/kotlin/com/denser/hyphen/ui/internal/EditorExtensions.kt
+++ b/hyphen/src/commonMain/kotlin/com/denser/hyphen/ui/internal/EditorExtensions.kt
@@ -2,6 +2,15 @@ package com.denser.hyphen.ui.internal
 
 import androidx.compose.foundation.text.input.TextFieldBuffer
 import androidx.compose.foundation.text.input.insert
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.ScrollState
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
@@ -134,6 +143,18 @@ internal fun applyMarkdownStyles(
             }
         }
 
+        val blockquotes = state.spans
+            .filter { it.style is MarkupStyle.Blockquote }
+            .sortedByDescending { it.start }
+
+        blockquotes.forEach { bq ->
+            val safeStart = (bq.start + adjustment).coerceIn(0, length)
+            val safeEnd = (bq.start + adjustment + 1).coerceIn(0, length)
+            if (safeStart < safeEnd) {
+                replace(safeStart, safeEnd, " ")
+            }
+        }
+
         val baseSpanStyle = baseTextStyle.toSpanStyle()
         val currentTextSeq = asCharSequence()
         for (i in currentTextSeq.indices) {
@@ -207,10 +228,31 @@ internal fun processMarkdownInput(
     val newText = buffer.asCharSequence().toString()
 
     val cursorBefore = state.selection.start
-    val isSoftEnter = cursorBefore < newText.length &&
-            newText[cursorBefore] == '\n' &&
-            newText.length == previousText.length + 1 &&
-            newText.removeRange(cursorBefore, cursorBefore + 1) == previousText
+    
+    // Check if a single character was deleted (Backspace)
+    if (newText.length == previousText.length - 1 && cursorBefore > 0) {
+        val lastNewline = previousText.lastIndexOf('\n', (cursorBefore - 1).coerceAtLeast(0))
+        val lineStart = if (lastNewline == -1) 0 else lastNewline + 1
+        
+        if (state.isStyleAt(lineStart, MarkupStyle.Blockquote) && cursorBefore == lineStart + 2) {
+            if (lineStart < buffer.length && buffer.asCharSequence()[lineStart] == '>') {
+                buffer.replace(lineStart, lineStart + 1, "")
+            }
+        } else if ((state.isStyleAt(lineStart, MarkupStyle.CheckboxUnchecked) || state.isStyleAt(lineStart, MarkupStyle.CheckboxChecked)) && cursorBefore == lineStart + 6) {
+            val prefixEnd = lineStart + 5
+            if (prefixEnd <= buffer.length) {
+                val prefix = buffer.asCharSequence().substring(lineStart, prefixEnd)
+                if (prefix == "- [ ]" || prefix == "* [ ]" || prefix == "- [x]" || prefix == "* [x]" || prefix == "- [X]" || prefix == "* [X]") {
+                    buffer.replace(lineStart, prefixEnd, "")
+                }
+            }
+        }
+    }
+
+    val isSoftEnter = cursorBefore < buffer.length &&
+            buffer.asCharSequence()[cursorBefore] == '\n' &&
+            buffer.length == previousText.length + 1 &&
+            buffer.asCharSequence().toString().removeRange(cursorBefore, cursorBefore + 1) == previousText
 
     if (isSoftEnter) {
         buffer.revertAllChanges()
@@ -228,3 +270,67 @@ internal expect fun rememberMarkdownClipboard(
     state: HyphenTextState,
     clipboardLabel: String,
 ): Clipboard
+
+internal fun Modifier.drawBlockquotes(
+    state: HyphenTextState,
+    styleConfig: HyphenStyleConfig,
+    textLayoutResult: () -> TextLayoutResult?,
+    scrollState: ScrollState
+): Modifier = this.drawBehind {
+    val layout = textLayoutResult() ?: return@drawBehind
+    val textLen = layout.layoutInput.text.length
+    val scrollY = scrollState.value
+
+    val intervals = state.spans
+        .filter { it.style is MarkupStyle.Blockquote }
+        .mapNotNull { span ->
+            val visualStart = HyphenOffsetMapper.toVisual(span.start, state).coerceIn(0, textLen)
+            val visualEnd = HyphenOffsetMapper.toVisual(span.end, state).coerceIn(0, textLen)
+            if (visualStart >= visualEnd) return@mapNotNull null
+
+            val startLine = layout.getLineForOffset(visualStart)
+            val endLine = layout.getLineForOffset(visualEnd)
+
+            val top = layout.getLineTop(startLine) - scrollY
+            val bottom = layout.getLineBottom(endLine) - scrollY
+            top to bottom
+        }
+        .sortedBy { it.first }
+
+    if (intervals.isNotEmpty()) {
+        val mergedIntervals = mutableListOf<Pair<Float, Float>>()
+        var current = intervals[0]
+        for (i in 1 until intervals.size) {
+            val next = intervals[i]
+            if (next.first <= current.second + 2f) {
+                current = current.first to maxOf(current.second, next.second)
+            } else {
+                mergedIntervals.add(current)
+                current = next
+            }
+        }
+        mergedIntervals.add(current)
+
+        val bqStyle = styleConfig.blockquoteStyle
+
+        mergedIntervals.forEach { (top, bottom) ->
+            // Draw background with slightly rounded corners
+            drawRoundRect(
+                color = bqStyle.backgroundColor,
+                topLeft = Offset(0f, top),
+                size = Size(size.width - 8.dp.toPx(), bottom - top),
+                cornerRadius = CornerRadius(bqStyle.cornerRadius.toPx())
+            )
+
+            // Draw thick border on the left with rounded corners
+            val borderWidth = bqStyle.borderWidth.toPx()
+            val borderLeft = 4.dp.toPx()
+            drawRoundRect(
+                color = bqStyle.borderColor,
+                topLeft = Offset(borderLeft, top),
+                size = Size(borderWidth, bottom - top),
+                cornerRadius = CornerRadius(bqStyle.borderCornerRadius.toPx())
+            )
+        }
+    }
+}

--- a/hyphen/src/commonMain/kotlin/com/denser/hyphen/ui/style/HyphenStyleConfig.kt
+++ b/hyphen/src/commonMain/kotlin/com/denser/hyphen/ui/style/HyphenStyleConfig.kt
@@ -8,6 +8,8 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 
 /**
  * Visual style applied to the prefix marker and content text of a list item.
@@ -85,9 +87,7 @@ data class HyphenStyleConfig(
         fontFamily = FontFamily.Monospace,
     ),
     val blockquoteSpanStyle: SpanStyle = SpanStyle(
-        fontStyle = FontStyle.Italic,
         color = Color.Gray,
-        background = Color.Gray.copy(alpha = 0.05f),
     ),
     val bulletListStyle: ListItemStyle = ListItemStyle(),
     val orderedListStyle: ListItemStyle = ListItemStyle(),
@@ -119,4 +119,23 @@ data class HyphenStyleConfig(
      * If a scheme is not present in this map, it falls back to [mentionStyle].
      */
     val mentionStyles: Map<String, SpanStyle> = emptyMap(),
+    val blockquoteStyle: BlockquoteStyle = BlockquoteStyle(),
+)
+
+/**
+ * Visual configuration for blockquotes.
+ *
+ * @property backgroundColor Color of the blockquote highlight block.
+ * @property borderColor Color of the thick border on the left.
+ * @property borderWidth Thickness of the left border.
+ * @property cornerRadius Corner radius of the blockquote highlight background.
+ * @property borderCornerRadius Corner radius of the thick border.
+ */
+@Immutable
+data class BlockquoteStyle(
+    val backgroundColor: Color = Color.Gray.copy(alpha = 0.08f),
+    val borderColor: Color = Color.Gray.copy(alpha = 0.4f),
+    val borderWidth: Dp = 3.dp,
+    val cornerRadius: Dp = 4.dp,
+    val borderCornerRadius: Dp = 2.dp,
 )

--- a/hyphen/src/commonTest/kotlin/com/denser/hyphen/ui/EditorExtensionsTest.kt
+++ b/hyphen/src/commonTest/kotlin/com/denser/hyphen/ui/EditorExtensionsTest.kt
@@ -25,7 +25,7 @@ class EditorExtensionsTest {
 
         val resultingText = bufferState.text.toString()
         assertTrue(
-            resultingText.contains("- Item 1\n- "),
+            resultingText.contains("- Item 1\n-\u00A0"),
             "Expected SmartEnter to intercept the newline and insert a new bullet point, but got: $resultingText"
         )
     }
@@ -45,7 +45,7 @@ class EditorExtensionsTest {
 
         val resultingText = bufferState.text.toString()
         assertEquals(
-            "- [ ] Task 1\n- [ ] ",
+            "- [ ] Task 1\n- [ ]\u00A0",
             resultingText,
             "Expected SmartEnter to append a new unchecked checkbox."
         )
@@ -66,7 +66,7 @@ class EditorExtensionsTest {
 
         val resultingText = bufferState.text.toString()
         assertEquals(
-            "- [x] Done task\n- [ ] ",
+            "- [x] Done task\n- [ ]\u00A0",
             resultingText,
             "Expected SmartEnter on a checked task to append a new UNCHECKED checkbox."
         )
@@ -109,7 +109,7 @@ class EditorExtensionsTest {
 
         val resultingText = bufferState.text.toString()
         assertEquals(
-            "1. First step\n2. ",
+            "1. First step\n2.\u00A0",
             resultingText,
             "Expected SmartEnter to increment the ordered list number to 2."
         )
@@ -133,6 +133,88 @@ class EditorExtensionsTest {
             "",
             resultingText,
             "Expected SmartEnter on an empty bullet item to exit the list."
+        )
+    }
+
+    @Test
+    fun testProcessMarkdownInput_softEnterOnBlockquote_appendsNewBlockquotePrefix() {
+        val text = "> Quote"
+        val state = HyphenTextState(initialText = text)
+        state.textFieldState.setTextAndPlaceCursorAtEnd(text)
+
+        val bufferState = TextFieldState(text)
+
+        bufferState.edit {
+            insert(length, "\n")
+            processMarkdownInput(state = state, buffer = this)
+        }
+
+        val resultingText = bufferState.text.toString()
+        assertEquals(
+            "> Quote\n>\u00A0",
+            resultingText,
+            "Expected SmartEnter to append a new blockquote prefix."
+        )
+    }
+
+    @Test
+    fun testProcessMarkdownInput_softEnterOnEmptyBlockquote_removesBlockquotePrefix() {
+        val text = "> "
+        val state = HyphenTextState(initialText = text)
+        state.textFieldState.setTextAndPlaceCursorAtEnd(text)
+
+        val bufferState = TextFieldState(text)
+
+        bufferState.edit {
+            insert(length, "\n")
+            processMarkdownInput(state = state, buffer = this)
+        }
+
+        val resultingText = bufferState.text.toString()
+        assertEquals(
+            "",
+            resultingText,
+            "Expected SmartEnter on an empty blockquote to remove prefix."
+        )
+    }
+
+    @Test
+    fun testProcessMarkdownInput_backspaceOnEmptyBlockquotePrefix_clearsEntirePrefix() {
+        val text = "> "
+        val state = HyphenTextState(initialText = text)
+        state.textFieldState.setTextAndPlaceCursorAtEnd(text) // cursor at index 2
+
+        val bufferState = TextFieldState(">") // simulate deleting the space
+
+        bufferState.edit {
+            processMarkdownInput(state = state, buffer = this)
+        }
+
+        val resultingText = bufferState.text.toString()
+        assertEquals(
+            "",
+            resultingText,
+            "Expected Backspace on empty blockquote prefix to clear the rest of the prefix."
+        )
+    }
+
+    @Test
+    fun testProcessMarkdownInput_backspaceOnEmptyCheckboxPrefix_clearsEntirePrefix() {
+        val text = "- [ ] "
+        val state = HyphenTextState(initialText = text)
+        state.textFieldState.setTextAndPlaceCursorAtEnd(text) // cursor at index 6
+
+        val bufferState = TextFieldState("- [ ]") // simulate deleting the trailing space
+
+        bufferState.edit {
+            processMarkdownInput(state = state, buffer = this)
+        }
+
+        val resultingText = bufferState.text.toString()
+        assertEquals(
+            "",
+            resultingText,
+            "Expected Backspace on empty checkbox prefix to clear the rest of the prefix."
         )
     }
 }

--- a/sample/shared/src/commonMain/kotlin/com/denser/hyphen/sample/shared/HyphenSampleApp.kt
+++ b/sample/shared/src/commonMain/kotlin/com/denser/hyphen/sample/shared/HyphenSampleApp.kt
@@ -9,42 +9,25 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.ScrollState
-import androidx.compose.foundation.background
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonDefaults
-import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.foundation.layout.widthIn
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.DpOffset
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -52,23 +35,16 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.focusProperties
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.denser.hyphen.state.HyphenTextState
 import com.denser.hyphen.state.rememberHyphenTextState
 import com.denser.hyphen.ui.HyphenBasicTextEditor
-import androidx.compose.ui.platform.LocalUriHandler
 import com.denser.hyphen.sample.shared.components.MarkdownPreviewPanel
 import com.denser.hyphen.sample.shared.components.StateInspectorPanel
 import com.denser.hyphen.sample.shared.components.SampleTriggerPopup
@@ -85,12 +61,9 @@ import com.denser.hyphen.sample.shared.data.initDatabase
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.coroutines.launch
-import org.jetbrains.compose.resources.painterResource
 import com.denser.hyphen.model.TriggerConfig
-import com.denser.hyphen.model.TriggerState
 import com.denser.hyphen.ui.mention.HyphenMentionConfig
 import com.denser.hyphen.model.MarkupStyle
-import com.denser.hyphen.ui.style.HyphenStyleConfig
 
 
 typealias VerticalScrollbarSlot = @Composable (scrollState: ScrollState, modifier: Modifier) -> Unit
@@ -313,7 +286,7 @@ private fun EditorPane(
                 showDefaultSuggestionsPopup = !isAndroid,
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(12.dp),
+                    .padding(vertical = 12.dp),
                 textStyle = TextStyle(
                     fontSize = 16.sp,
                     color = MaterialTheme.colorScheme.onSurface,


### PR DESCRIPTION
## Overview
This PR introduces custom block-level styling for **Blockquotes** and resolves minor prefix and space-matching issues for **Checkboxes** in the Hyphen editor.

## Key Features
- **Blockquote Styling**: Draws a full-width background and left border with rounded corners. Adjacent lines are merged, and horizontal padding is added to prevent wrapped text lines from intersecting the border. 
- **Blockquote Configurations**: Adds a `BlockquoteStyle` configuration to `HyphenStyleConfig` to customize colors, border width, and corner radii.
- **Smart Enter & Backspace Support**: Extends existing list mechanics (smart enter continuation/clearing and clean backspace prefix deletion) to blockquotes.
- **Instant Checklist & Blockquote Triggering**: Updates blockquote and checkbox regexes to match non-breaking spaces (`\u00A0`), enabling formatting to trigger immediately upon typing the prefix space.
- **Unit Tests**: Adds tests verifying blockquote integration and checkbox test assertions.

**Closes: #9**