### PR TITLE
feat: Indented Lists

### DIFF
--- a/hyphen/src/commonMain/kotlin/com/denser/hyphen/markdown/MarkdownConstants.kt
+++ b/hyphen/src/commonMain/kotlin/com/denser/hyphen/markdown/MarkdownConstants.kt
@@ -46,15 +46,15 @@ internal object MarkdownConstants {
         option = RegexOption.MULTILINE
     )
 
-    // - [ ] or * [ ] at line start
+    // - [ ] or * [ ] at line start (with optional leading indentation)
     val CHECKBOX_UNCHECKED_REGEX = Regex(
-        pattern = """^[\-*][ \u00A0]\[\s\][ \u00A0](.*?)$""",
+        pattern = """^[ \t]*[\-*][ \u00A0]\[\s\][ \u00A0](.*?)$""",
         option = RegexOption.MULTILINE
     )
 
-    // - [x] or * [X] at line start
+    // - [x] or * [X] at line start (with optional leading indentation)
     val CHECKBOX_CHECKED_REGEX = Regex(
-        pattern = """^[\-*][ \u00A0]\[[xX]\][ \u00A0](.*?)$""",
+        pattern = """^[ \t]*[\-*][ \u00A0]\[[xX]\][ \u00A0](.*?)$""",
         option = RegexOption.MULTILINE
     )
 

--- a/hyphen/src/commonMain/kotlin/com/denser/hyphen/markdown/MarkdownConstants.kt
+++ b/hyphen/src/commonMain/kotlin/com/denser/hyphen/markdown/MarkdownConstants.kt
@@ -28,15 +28,15 @@ internal object MarkdownConstants {
     // [display](scheme:id)
     const val MENTION_REGEX_TEMPLATE = """\[(.+?)\]\((%s):(.+?)\)"""
 
-    // -, *, or • at line start
+    // -, *, or • at line start (with optional leading indentation)
     val BULLET_LIST_REGEX = Regex(
-        pattern = """^[\-*•][ \u00A0](.*?)$""",
+        pattern = """^[ \t]*[\-*•][ \u00A0](.*?)$""",
         option = RegexOption.MULTILINE
     )
 
-    // 1. at line start
+    // 1. at line start (with optional leading indentation)
     val ORDERED_LIST_REGEX = Regex(
-        pattern = """^\d+\.[ \u00A0](.*?)$""",
+        pattern = """^[ \t]*\d+\.[ \u00A0](.*?)$""",
         option = RegexOption.MULTILINE
     )
 

--- a/hyphen/src/commonMain/kotlin/com/denser/hyphen/markdown/MarkdownProcessor.kt
+++ b/hyphen/src/commonMain/kotlin/com/denser/hyphen/markdown/MarkdownProcessor.kt
@@ -145,8 +145,11 @@ internal object MarkdownProcessor {
         applyRule(
             MarkdownConstants.BULLET_LIST_REGEX,
             { MarkupStyle.BulletList },
-            getPrefixRemoved = { 2 },
-            getPrefixAdded = { match -> match.value.substring(0, 2) }
+            getPrefixRemoved = { match ->
+                val leadingSpaces = match.value.takeWhile { it == ' ' || it == '\t' }.length
+                leadingSpaces + 2
+            },
+            getPrefixAdded = { match -> match.value.substring(0, match.value.takeWhile { it == ' ' || it == '\t' }.length + 2) }
         )
         applyRule(
             MarkdownConstants.BLOCKQUOTE_REGEX,
@@ -157,8 +160,15 @@ internal object MarkdownProcessor {
         applyRule(
             MarkdownConstants.ORDERED_LIST_REGEX,
             { MarkupStyle.OrderedList },
-            getPrefixRemoved = { match -> match.value.indexOf('.') + 2 },
-            getPrefixAdded = { match -> match.value.substring(0, match.value.indexOf('.') + 2) }
+            getPrefixRemoved = { match ->
+                val leadingSpaces = match.value.takeWhile { it == ' ' || it == '\t' }.length
+                match.value.indexOf('.', leadingSpaces) + 2
+            },
+            getPrefixAdded = { match ->
+                val leadingSpaces = match.value.takeWhile { it == ' ' || it == '\t' }.length
+                val dotIndex = match.value.indexOf('.', leadingSpaces)
+                match.value.substring(0, dotIndex + 2)
+            }
         )
 
         triggerConfigs.forEach { config ->

--- a/hyphen/src/commonMain/kotlin/com/denser/hyphen/markdown/MarkdownProcessor.kt
+++ b/hyphen/src/commonMain/kotlin/com/denser/hyphen/markdown/MarkdownProcessor.kt
@@ -132,15 +132,35 @@ internal object MarkdownProcessor {
         applyRule(
             MarkdownConstants.CHECKBOX_UNCHECKED_REGEX,
             { MarkupStyle.CheckboxUnchecked },
-            getPrefixRemoved = { 6 },
-            getPrefixAdded = { match -> match.value.substring(0, 6) }
+            getPrefixRemoved = { match ->
+                val leadingSpaces = match.value.takeWhile { it == ' ' || it == '\t' }.length
+                leadingSpaces + 6
+            },
+            getPrefixAdded = { match ->
+                val leadingSpaces = match.value.takeWhile { it == ' ' || it == '\t' }.length
+                match.value.substring(0, leadingSpaces + 6)
+            }
         )
         applyRule(
             MarkdownConstants.CHECKBOX_CHECKED_REGEX,
             { MarkupStyle.CheckboxChecked },
-            getPrefixRemoved = { 6 },
-            getPrefixAdded = { match -> match.value.substring(0, 6) }
+            getPrefixRemoved = { match ->
+                val leadingSpaces = match.value.takeWhile { it == ' ' || it == '\t' }.length
+                leadingSpaces + 6
+            },
+            getPrefixAdded = { match ->
+                val leadingSpaces = match.value.takeWhile { it == ' ' || it == '\t' }.length
+                match.value.substring(0, leadingSpaces + 6)
+            }
         )
+
+        extractedSpans = extractedSpans.map { span ->
+            if (span.style is MarkupStyle.CheckboxUnchecked || span.style is MarkupStyle.CheckboxChecked) {
+                val rawStart = span.start.coerceIn(0, processedText.length)
+                val indentLen = processedText.substring(rawStart).takeWhile { it == ' ' || it == '\t' }.length
+                if (indentLen > 0) span.copy(start = span.start + indentLen) else span
+            } else span
+        }
 
         applyRule(
             MarkdownConstants.BULLET_LIST_REGEX,

--- a/hyphen/src/commonMain/kotlin/com/denser/hyphen/state/BlockStyleManager.kt
+++ b/hyphen/src/commonMain/kotlin/com/denser/hyphen/state/BlockStyleManager.kt
@@ -65,9 +65,11 @@ internal object BlockStyleManager {
         val indent = fullLineText.takeWhile { it == ' ' || it == '\t' }
         val unindentedLine = fullLineText.substring(indent.length)
 
+        val styleCheckIndex = lineStart + indent.length
+
         return when {
-            (state.isStyleAt(lineStart, MarkupStyle.CheckboxUnchecked) || state.isStyleAt(lineStart, MarkupStyle.CheckboxChecked)) -> {
-                val isPrefixOnly = Regex("""^[\-*][ \u00A0]\[\s\][ \u00A0]?$""").matches(unindentedLine)
+            (state.isStyleAt(styleCheckIndex, MarkupStyle.CheckboxUnchecked) || state.isStyleAt(styleCheckIndex, MarkupStyle.CheckboxChecked)) -> {
+                val isPrefixOnly = Regex("""^[\-*][ \u00A0]\[[\s\S]\][ \u00A0]?$""").matches(unindentedLine)
                 if (isPrefixOnly) {
                     buffer.replace(lineStart, lineEnd, "")
                 } else {
@@ -77,7 +79,7 @@ internal object BlockStyleManager {
                 true
             }
 
-            state.isStyleAt(lineStart, MarkupStyle.BulletList) -> {
+            state.isStyleAt(styleCheckIndex, MarkupStyle.BulletList) -> {
                 val isPrefixOnly = Regex("""^[\-*•][ \u00A0]?$""").matches(unindentedLine)
                 if (isPrefixOnly) {
                     buffer.replace(lineStart, lineEnd, "")
@@ -97,7 +99,7 @@ internal object BlockStyleManager {
                 true
             }
 
-            state.isStyleAt(lineStart, MarkupStyle.OrderedList) -> {
+            state.isStyleAt(styleCheckIndex, MarkupStyle.OrderedList) -> {
                 val dotIndex = unindentedLine.indexOf('.')
                 val isPrefixOnly = Regex("""^\d+\.[ \u00A0]?$""").matches(unindentedLine)
                 if (isPrefixOnly) {
@@ -109,7 +111,7 @@ internal object BlockStyleManager {
                 true
             }
 
-            state.isStyleAt(lineStart, MarkupStyle.Blockquote) -> {
+            state.isStyleAt(styleCheckIndex, MarkupStyle.Blockquote) -> {
                 val isPrefixOnly = Regex("""^>[ \u00A0]?$""").matches(fullLineText)
                 if (isPrefixOnly) {
                     buffer.replace(lineStart, lineEnd, "")
@@ -294,7 +296,7 @@ internal object BlockStyleManager {
         return false to spans
     }
 
-    fun handleIndent(state: HyphenTextState, buffer: TextFieldBuffer, isShift: Boolean) {
+    fun handleIndent(state: HyphenTextState, buffer: TextFieldBuffer, isShift: Boolean, indentSpaces: Int = 2): Boolean {
         val bufferText = buffer.asCharSequence()
         val selStart = minOf(buffer.selection.start, buffer.selection.end)
         val selEnd = maxOf(buffer.selection.start, buffer.selection.end)
@@ -314,6 +316,9 @@ internal object BlockStyleManager {
             } else break
         }
 
+        val indentString = " ".repeat(indentSpaces.coerceAtLeast(1))
+
+        var modified = false
         var currentSpans = state.spans
         for (start in lineStarts.reversed()) {
             val lineEnd = bufferText.indexOf('\n', start).let { if (it == -1) buffer.length else it }
@@ -321,17 +326,22 @@ internal object BlockStyleManager {
             val indentLen = lineText.takeWhile { it == ' ' || it == '\t' }.length
 
             if (!isShift) {
-                buffer.insert(start, "  ")
-                currentSpans = SpanManager.shiftSpans(currentSpans, start, 2, push = true)
+                buffer.insert(start, indentString)
+                currentSpans = SpanManager.shiftSpans(currentSpans, start, indentString.length, push = true)
+                modified = true
             } else {
                 if (indentLen > 0) {
-                    val removeCount = minOf(2, indentLen)
+                    val removeCount = minOf(indentSpaces.coerceAtLeast(1), indentLen)
                     buffer.replace(start, start + removeCount, "")
                     currentSpans = SpanManager.shiftSpans(currentSpans, start, -removeCount)
+                    modified = true
                 }
             }
         }
-        state._spans.clear()
-        state._spans.addAll(currentSpans)
+        if (modified) {
+            state._spans.clear()
+            state._spans.addAll(currentSpans)
+        }
+        return modified
     }
 }

--- a/hyphen/src/commonMain/kotlin/com/denser/hyphen/state/BlockStyleManager.kt
+++ b/hyphen/src/commonMain/kotlin/com/denser/hyphen/state/BlockStyleManager.kt
@@ -62,46 +62,49 @@ internal object BlockStyleManager {
         val lineEnd = bufferText.indexOf('\n', lineStart).let { if (it == -1) bufferText.length else it }
         val fullLineText = bufferText.substring(lineStart, lineEnd)
 
+        val indent = fullLineText.takeWhile { it == ' ' || it == '\t' }
+        val unindentedLine = fullLineText.substring(indent.length)
+
         return when {
             (state.isStyleAt(lineStart, MarkupStyle.CheckboxUnchecked) || state.isStyleAt(lineStart, MarkupStyle.CheckboxChecked)) -> {
-                val isPrefixOnly = Regex("""^[\-*][ \u00A0]\[\s\][ \u00A0]?$""").matches(fullLineText)
+                val isPrefixOnly = Regex("""^[\-*][ \u00A0]\[\s\][ \u00A0]?$""").matches(unindentedLine)
                 if (isPrefixOnly) {
                     buffer.replace(lineStart, lineEnd, "")
                 } else {
-                    val prefix = if (fullLineText.startsWith("*")) "* [ ] " else "- [ ] "
-                    buffer.insert(cursor, "\n$prefix")
+                    val prefix = if (unindentedLine.startsWith("*")) "* [ ] " else "- [ ] "
+                    buffer.insert(cursor, "\n$indent$prefix")
                 }
                 true
             }
 
             state.isStyleAt(lineStart, MarkupStyle.BulletList) -> {
-                val isPrefixOnly = Regex("""^[\-*•][ \u00A0]?$""").matches(fullLineText)
+                val isPrefixOnly = Regex("""^[\-*•][ \u00A0]?$""").matches(unindentedLine)
                 if (isPrefixOnly) {
                     buffer.replace(lineStart, lineEnd, "")
                 } else {
-                    val prefix = if (fullLineText.isNotEmpty()) {
-                        val firstChar = fullLineText[0]
+                    val prefix = if (unindentedLine.isNotEmpty()) {
+                        val firstChar = unindentedLine[0]
                         if (firstChar == '-' || firstChar == '*' || firstChar == '•') {
-                            if (fullLineText.length >= 2 && (fullLineText[1] == ' ' || fullLineText[1] == '\u00A0')) {
-                                fullLineText.take(2)
+                            if (unindentedLine.length >= 2 && (unindentedLine[1] == ' ' || unindentedLine[1] == '\u00A0')) {
+                                unindentedLine.take(2)
                             } else {
                                 "$firstChar "
                             }
                         } else "- "
                     } else "- "
-                    buffer.insert(cursor, "\n$prefix")
+                    buffer.insert(cursor, "\n$indent$prefix")
                 }
                 true
             }
 
             state.isStyleAt(lineStart, MarkupStyle.OrderedList) -> {
-                val dotIndex = fullLineText.indexOf('.')
-                val isPrefixOnly = Regex("""^\d+\.[ \u00A0]?$""").matches(fullLineText)
+                val dotIndex = unindentedLine.indexOf('.')
+                val isPrefixOnly = Regex("""^\d+\.[ \u00A0]?$""").matches(unindentedLine)
                 if (isPrefixOnly) {
                     buffer.replace(lineStart, lineEnd, "")
                 } else {
-                    val currentNumber = if (dotIndex != -1) fullLineText.substring(0, dotIndex).toIntOrNull() ?: 1 else 1
-                    buffer.insert(cursor, "\n${currentNumber + 1}. ")
+                    val currentNumber = if (dotIndex != -1) unindentedLine.substring(0, dotIndex).toIntOrNull() ?: 1 else 1
+                    buffer.insert(cursor, "\n$indent${currentNumber + 1}. ")
                 }
                 true
             }
@@ -177,9 +180,12 @@ internal object BlockStyleManager {
             val lineEnd = bufferText.indexOf('\n', lineStart).let { if (it == -1) buffer.length else it }
             val lineText = bufferText.substring(lineStart, lineEnd)
 
+            val leadingIndentLen = lineText.takeWhile { it == ' ' || it == '\t' }.length
+            val unindentedText = lineText.substring(leadingIndentLen)
+
             var existingPrefixLen = 0
             if (MarkdownConstants.ORDERED_LIST_REGEX.containsMatchIn(lineText)) {
-                existingPrefixLen = lineText.indexOf('.') + 2
+                existingPrefixLen = unindentedText.indexOf('.') + 2
             } else if (MarkdownConstants.CHECKBOX_UNCHECKED_REGEX.containsMatchIn(lineText) || MarkdownConstants.CHECKBOX_CHECKED_REGEX.containsMatchIn(lineText)) {
                 existingPrefixLen = 6
             } else if (MarkdownConstants.BULLET_LIST_REGEX.containsMatchIn(lineText)) {
@@ -187,6 +193,8 @@ internal object BlockStyleManager {
             } else if (MarkdownConstants.BLOCKQUOTE_REGEX.containsMatchIn(lineText)) {
                 existingPrefixLen = 2
             }
+
+            val prefixStart = lineStart + leadingIndentLen
 
             if (isRemoving) {
                 val matchTarget = when (style) {
@@ -200,27 +208,27 @@ internal object BlockStyleManager {
                 }
 
                 if (matchTarget && existingPrefixLen > 0) {
-                    buffer.replace(lineStart, lineStart + existingPrefixLen, "")
-                    currentSpans = SpanManager.shiftSpans(currentSpans, lineStart, -existingPrefixLen)
+                    buffer.replace(prefixStart, prefixStart + existingPrefixLen, "")
+                    currentSpans = SpanManager.shiftSpans(currentSpans, prefixStart, -existingPrefixLen)
                 }
             } else {
                 val actualPrefix = if (style is MarkupStyle.OrderedList) "1. " else prefix
 
                 if (existingPrefixLen > 0) {
-                    val existingPrefix = lineText.take(existingPrefixLen)
+                    val existingPrefix = unindentedText.take(existingPrefixLen)
                     if (existingPrefix != actualPrefix) {
-                        buffer.replace(lineStart, lineStart + existingPrefixLen, actualPrefix)
+                        buffer.replace(prefixStart, prefixStart + existingPrefixLen, actualPrefix)
                         val diff = actualPrefix.length - existingPrefixLen
-                        currentSpans = SpanManager.shiftSpans(currentSpans, lineStart, diff, push = true)
+                        currentSpans = SpanManager.shiftSpans(currentSpans, prefixStart, diff, push = true)
                     }
                 } else {
-                    buffer.insert(lineStart, actualPrefix)
-                    currentSpans = SpanManager.shiftSpans(currentSpans, lineStart, actualPrefix.length, push = true)
+                    buffer.insert(prefixStart, actualPrefix)
+                    currentSpans = SpanManager.shiftSpans(currentSpans, prefixStart, actualPrefix.length, push = true)
                 }
             }
         }
 
-        var listCounter = 1
+        val listCounters = mutableMapOf<String, Int>()
         var currentLineStart = 0
         while (currentLineStart < buffer.length) {
             val bufferStr = buffer.asCharSequence()
@@ -229,20 +237,26 @@ internal object BlockStyleManager {
             val lineText = bufferStr.substring(currentLineStart, lineEnd)
 
             if (MarkdownConstants.ORDERED_LIST_REGEX.containsMatchIn(lineText)) {
-                val oldPrefixLen = lineText.indexOf('.') + 2
-                val oldPrefix = lineText.take(oldPrefixLen)
+                val indent = lineText.takeWhile { it == ' ' || it == '\t' }
+                val unindented = lineText.substring(indent.length)
+                val oldPrefixLen = unindented.indexOf('.') + 2
+                val oldPrefix = unindented.take(oldPrefixLen)
+
+                val listCounter = (listCounters[indent] ?: 0) + 1
+                listCounters[indent] = listCounter
+
                 val newPrefix = "$listCounter. "
+                val prefixStart = currentLineStart + indent.length
                 if (oldPrefix != newPrefix) {
-                    buffer.replace(currentLineStart, currentLineStart + oldPrefixLen, newPrefix)
+                    buffer.replace(prefixStart, prefixStart + oldPrefixLen, newPrefix)
                     val diff = newPrefix.length - oldPrefixLen
-                    currentSpans = SpanManager.shiftSpans(currentSpans, currentLineStart + oldPrefixLen, diff)
+                    currentSpans = SpanManager.shiftSpans(currentSpans, prefixStart + oldPrefixLen, diff)
                     currentLineStart = lineEnd + diff + 1
                 } else {
                     currentLineStart = lineEnd + 1
                 }
-                listCounter++
             } else {
-                listCounter = 1
+                listCounters.clear()
                 currentLineStart = lineEnd + 1
             }
         }
@@ -263,18 +277,61 @@ internal object BlockStyleManager {
         val lineEnd = bufferText.indexOf('\n', lineStart).let { if (it == -1) buffer.length else it }
         val lineText = bufferText.substring(lineStart, lineEnd)
 
-        val isInPrefix = offset >= lineStart && offset <= lineStart + 6
+        val indentLen = lineText.takeWhile { it == ' ' || it == '\t' }.length
+        val prefixStart = lineStart + indentLen
+        val isInPrefix = offset >= lineStart && offset <= prefixStart + 6
 
         if (!strictPrefixCheck || isInPrefix) {
             if (MarkdownConstants.CHECKBOX_UNCHECKED_REGEX.containsMatchIn(lineText)) {
-                buffer.replace(lineStart, lineStart + 6, "- [x] ")
+                buffer.replace(prefixStart, prefixStart + 6, "- [x] ")
                 return true to spans
             }
             if (MarkdownConstants.CHECKBOX_CHECKED_REGEX.containsMatchIn(lineText)) {
-                buffer.replace(lineStart, lineStart + 6, "- [ ] ")
+                buffer.replace(prefixStart, prefixStart + 6, "- [ ] ")
                 return true to spans
             }
         }
         return false to spans
+    }
+
+    fun handleIndent(state: HyphenTextState, buffer: TextFieldBuffer, isShift: Boolean) {
+        val bufferText = buffer.asCharSequence()
+        val selStart = minOf(buffer.selection.start, buffer.selection.end)
+        val selEnd = maxOf(buffer.selection.start, buffer.selection.end)
+
+        val lineStarts = mutableListOf<Int>()
+        var currentStart = bufferText.lastIndexOf('\n', (selStart - 1).coerceAtLeast(0)) + 1
+        if (currentStart == -1) currentStart = 0
+        lineStarts.add(currentStart)
+
+        var searchIndex = currentStart
+        while (searchIndex < selEnd) {
+            val nextNewline = bufferText.indexOf('\n', searchIndex)
+            if (nextNewline != -1 && nextNewline < selEnd) {
+                if (nextNewline == selEnd - 1 && selStart != selEnd) break
+                lineStarts.add(nextNewline + 1)
+                searchIndex = nextNewline + 1
+            } else break
+        }
+
+        var currentSpans = state.spans
+        for (start in lineStarts.reversed()) {
+            val lineEnd = bufferText.indexOf('\n', start).let { if (it == -1) buffer.length else it }
+            val lineText = bufferText.substring(start, lineEnd)
+            val indentLen = lineText.takeWhile { it == ' ' || it == '\t' }.length
+
+            if (!isShift) {
+                buffer.insert(start, "  ")
+                currentSpans = SpanManager.shiftSpans(currentSpans, start, 2, push = true)
+            } else {
+                if (indentLen > 0) {
+                    val removeCount = minOf(2, indentLen)
+                    buffer.replace(start, start + removeCount, "")
+                    currentSpans = SpanManager.shiftSpans(currentSpans, start, -removeCount)
+                }
+            }
+        }
+        state._spans.clear()
+        state._spans.addAll(currentSpans)
     }
 }

--- a/hyphen/src/commonMain/kotlin/com/denser/hyphen/state/HyphenTextState.kt
+++ b/hyphen/src/commonMain/kotlin/com/denser/hyphen/state/HyphenTextState.kt
@@ -412,6 +412,9 @@ class HyphenTextState(
 
             val modifiedMention = mentionSpans.find { mention ->
                 val display = (mention.style as MarkupStyle.Mention).display
+                val overlaps = editStart < mention.end && editEnd > mention.start
+                if (!overlaps) return@find false
+
                 val (checkStart, checkEnd) = when {
                     editEnd <= mention.start -> {
                         (mention.start + rawLengthDifference) to (mention.end + rawLengthDifference)
@@ -517,8 +520,8 @@ class HyphenTextState(
             val completedMentions = inlineBaseSpans.filter { it.style is MarkupStyle.Mention && it.style.id.isNotEmpty() }
 
             val filteredNewSpans = markdownResult.newSpans.filterNot { parsedSpan ->
-                parsedSpan.style is MarkupStyle.Mention && completedMentions.any { completed ->
-                    parsedSpan.start < completed.end && completed.start < parsedSpan.end
+                parsedSpan.style is MarkupStyle.Mention && inlineBaseSpans.any { existing ->
+                    existing.style is MarkupStyle.Mention && existing.start < parsedSpan.end && parsedSpan.start < existing.end
                 }
             }
 
@@ -558,9 +561,10 @@ class HyphenTextState(
 
             updatedSpans = finalSpans
 
-            buffer.replace(0, buffer.length, markdownResult.cleanText)
-            buffer.selection =
-                TextRange(markdownResult.newCursorPosition.coerceIn(0, buffer.length))
+            if (markdownResult.cleanText != newText && markdownResult.cleanText.length != newText.length) {
+                buffer.replace(0, buffer.length, markdownResult.cleanText)
+                buffer.selection = TextRange(markdownResult.newCursorPosition.coerceIn(0, buffer.length))
+            }
 
             val stylesJustClosed = markdownResult.explicitlyClosedStyles
 
@@ -573,7 +577,6 @@ class HyphenTextState(
             saveSnapshot()
         } else {
             var shifted = SpanManager.shiftSpans(safeSpans, changeOrigin, rawLengthDifference)
-            shifted = shifted.filterNot { BlockStyleManager.isBlockStyle(it.style) }
 
             if (rawLengthDifference > 0) {
                 val insertEnd = changeOrigin + rawLengthDifference
@@ -587,8 +590,6 @@ class HyphenTextState(
                 updatedSpans = shifted
             }
 
-            val inlineShifted = updatedSpans.filterNot { BlockStyleManager.isBlockStyle(it.style) }
-
             activeTrigger?.let { trigger ->
                 val triggerSpan = MarkupStyleRange(
                     style = MarkupStyle.Mention(
@@ -600,12 +601,12 @@ class HyphenTextState(
                     end = cursorPosition
                 )
 
-                val cleanedShifted = inlineShifted.filterNot { 
+                val cleanedShifted = updatedSpans.filterNot { 
                     it.style is MarkupStyle.Mention && (it.start == trigger.startIndex || it.style.id.isEmpty())
                 }
                 updatedSpans = (cleanedShifted + triggerSpan).distinct()
             } ?: run {
-                updatedSpans = inlineShifted.filterNot { 
+                updatedSpans = updatedSpans.filterNot { 
                     it.style is MarkupStyle.Mention && it.style.id.isEmpty()
                 }
             }
@@ -1194,7 +1195,7 @@ class HyphenTextState(
 
     private fun getCurrentSnapshot() = EditorSnapshot(text, selection, _spans.toList())
 
-    private fun saveSnapshot(force: Boolean = false) {
+    internal fun saveSnapshot(force: Boolean = false) {
         historyManager.saveSnapshot(getCurrentSnapshot(), force)
     }
 

--- a/hyphen/src/commonMain/kotlin/com/denser/hyphen/state/SpanManager.kt
+++ b/hyphen/src/commonMain/kotlin/com/denser/hyphen/state/SpanManager.kt
@@ -72,7 +72,7 @@ internal object SpanManager {
                           style is MarkupStyle.CheckboxChecked || style is MarkupStyle.CheckboxUnchecked
             
             if (isAtomic) {
-                consolidated.addAll(sorted)
+                consolidated.addAll(sorted.distinctBy { Triple(it.start, it.end, it.style) })
                 return@forEach
             }
 

--- a/hyphen/src/commonMain/kotlin/com/denser/hyphen/ui/HyphenBasicTextEditor.kt
+++ b/hyphen/src/commonMain/kotlin/com/denser/hyphen/ui/HyphenBasicTextEditor.kt
@@ -162,7 +162,7 @@ fun HyphenBasicTextEditor(
         BasicTextField(
             state = state.textFieldState,
             modifier = modifier
-                .onPreviewKeyEvent { event -> handleHardwareKeyEvent(event, state) }
+                .onPreviewKeyEvent { event -> handleHardwareKeyEvent(event, state, styleConfig) }
                 .onFocusChanged { focusState ->
                     state.isFocused = focusState.isFocused
                 },

--- a/hyphen/src/commonMain/kotlin/com/denser/hyphen/ui/internal/EditorExtensions.kt
+++ b/hyphen/src/commonMain/kotlin/com/denser/hyphen/ui/internal/EditorExtensions.kt
@@ -105,6 +105,14 @@ internal fun handleHardwareKeyEvent(
             consumed
         }
 
+        event.key == Key.Tab && !isPrimaryModifier && !isAlt -> {
+            state.textFieldState.edit {
+                BlockStyleManager.handleIndent(state, this, isShift)
+                state.processInput(this)
+            }
+            true
+        }
+
         isPrimaryModifier && !isShift && !isAlt -> {
             when (event.key) {
                 Key.B -> { state.toggleStyle(MarkupStyle.Bold); true }
@@ -159,6 +167,7 @@ internal fun applyMarkdownStyles(
             .filter { it.style is MarkupStyle.CheckboxUnchecked || it.style is MarkupStyle.CheckboxChecked }
 
         val adjustment = if (needsBaselineAnchor) 1 else 0
+        val sourceText = state.textFieldState.text.toString()
 
         val replacements = mutableListOf<TextRangeWith<String>>()
 
@@ -218,29 +227,34 @@ internal fun applyMarkdownStyles(
                 is MarkupStyle.Blockquote -> addStyle(styleConfig.blockquoteSpanStyle, visualStart, visualEnd)
 
                 is MarkupStyle.BulletList -> {
-                    val prefixEnd = (visualStart + 2).coerceAtMost(visualEnd)
+                    val lineText = currentTextSeq.substring(visualStart, visualEnd)
+                    val leadingSpaces = lineText.takeWhile { it == ' ' || it == '\t' }.length
+                    val prefixEnd = (visualStart + leadingSpaces + 2).coerceAtMost(visualEnd)
                     styleConfig.bulletListStyle.prefixStyle?.let { addStyle(it, visualStart, prefixEnd) }
                     styleConfig.bulletListStyle.contentStyle?.let { addStyle(it, prefixEnd, visualEnd) }
                 }
 
                 is MarkupStyle.OrderedList -> {
                     val lineText = currentTextSeq.substring(visualStart, visualEnd)
-                    val dotIndex = lineText.indexOf('.')
-                    val prefixLen = if (dotIndex != -1) (dotIndex + 2).coerceAtMost(lineText.length) else 3
+                    val leadingSpaces = lineText.takeWhile { it == ' ' || it == '\t' }.length
+                    val dotIndex = lineText.indexOf('.', leadingSpaces)
+                    val prefixLen = if (dotIndex != -1) (dotIndex + 2).coerceAtMost(lineText.length) else leadingSpaces + 3
                     val prefixEnd = (visualStart + prefixLen).coerceAtMost(visualEnd)
                     styleConfig.orderedListStyle.prefixStyle?.let { addStyle(it, visualStart, prefixEnd) }
                     styleConfig.orderedListStyle.contentStyle?.let { addStyle(it, prefixEnd, visualEnd) }
                 }
 
                 is MarkupStyle.CheckboxUnchecked -> {
+                    val slotStart = visualStart
                     val slotEnd = (visualStart + 2).coerceAtMost(visualEnd)
-                    addStyle(SpanStyle(letterSpacing = 0.8.em), visualStart, slotEnd)
+                    addStyle(SpanStyle(letterSpacing = 0.8.em), slotStart, slotEnd)
                     styleConfig.checkboxUncheckedStyle?.let { addStyle(it, slotEnd, visualEnd) }
                 }
 
                 is MarkupStyle.CheckboxChecked -> {
+                    val slotStart = visualStart
                     val slotEnd = (visualStart + 2).coerceAtMost(visualEnd)
-                    addStyle(SpanStyle(letterSpacing = 0.8.em), visualStart, slotEnd)
+                    addStyle(SpanStyle(letterSpacing = 0.8.em), slotStart, slotEnd)
                     styleConfig.checkboxCheckedStyle?.let { addStyle(it, slotEnd, visualEnd) }
                 }
 

--- a/hyphen/src/commonMain/kotlin/com/denser/hyphen/ui/internal/EditorExtensions.kt
+++ b/hyphen/src/commonMain/kotlin/com/denser/hyphen/ui/internal/EditorExtensions.kt
@@ -36,7 +36,8 @@ import com.denser.hyphen.ui.style.HyphenStyleConfig
 
 internal fun handleHardwareKeyEvent(
     event: KeyEvent,
-    state: HyphenTextState
+    state: HyphenTextState,
+    styleConfig: HyphenStyleConfig = HyphenStyleConfig(),
 ): Boolean {
     val isKeyDown = event.type == KeyEventType.KeyDown
     if (!isKeyDown) return false
@@ -74,26 +75,17 @@ internal fun handleHardwareKeyEvent(
         event.key == Key.Enter && !isPrimaryModifier && !isAlt -> {
             var consumed = false
             val hasSelection = !state.selection.collapsed
-            if (!hasSelection) {
-                if (!isShift) {
-                    state.textFieldState.edit {
-                        val handled = BlockStyleManager.handleSmartEnter(state, this)
-                        if (handled) {
-                            state.processInput(this)
-                            consumed = true
-                        }
+            if (!hasSelection && !isShift) {
+                state.saveSnapshot(force = true)
+                state.textFieldState.edit {
+                    consumed = BlockStyleManager.handleSmartEnter(state, this)
+                    if (consumed) {
+                        state.processInput(this)
                     }
                 }
-            } else {
-                state.textFieldState.edit {
-                    val selStart = minOf(selection.start, selection.end)
-                    val selEnd = maxOf(selection.start, selection.end)
-                    replace(selStart, selEnd, "\n")
-                    state.processInput(this)
-                }
-                consumed = true
             }
-            if (!consumed && isShift) {
+            if (!consumed) {
+                state.saveSnapshot(force = true)
                 state.textFieldState.edit {
                     val selStart = minOf(selection.start, selection.end)
                     val selEnd = maxOf(selection.start, selection.end)
@@ -106,9 +98,9 @@ internal fun handleHardwareKeyEvent(
         }
 
         event.key == Key.Tab && !isPrimaryModifier && !isAlt -> {
+            state.saveSnapshot(force = true)
             state.textFieldState.edit {
-                BlockStyleManager.handleIndent(state, this, isShift)
-                state.processInput(this)
+                BlockStyleManager.handleIndent(state, this, isShift, styleConfig.indentSpaces)
             }
             true
         }

--- a/hyphen/src/commonMain/kotlin/com/denser/hyphen/ui/internal/InlineContentHost.kt
+++ b/hyphen/src/commonMain/kotlin/com/denser/hyphen/ui/internal/InlineContentHost.kt
@@ -133,6 +133,7 @@ internal fun InlineContentHost(
                 val textLen = layoutResult.layoutInput.text.length
                 inlinePlaceables.forEach { (span, placeable) ->
                     if (textLen == 0) return@forEach
+
                     val transformedIndex = HyphenOffsetMapper.toVisual(span.start, state)
                         .coerceIn(0, textLen - 1)
                     val boundingBox = layoutResult.getBoundingBox(transformedIndex)

--- a/hyphen/src/commonMain/kotlin/com/denser/hyphen/ui/style/HyphenStyleConfig.kt
+++ b/hyphen/src/commonMain/kotlin/com/denser/hyphen/ui/style/HyphenStyleConfig.kt
@@ -120,6 +120,7 @@ data class HyphenStyleConfig(
      */
     val mentionStyles: Map<String, SpanStyle> = emptyMap(),
     val blockquoteStyle: BlockquoteStyle = BlockquoteStyle(),
+    val indentSpaces: Int = 2,
 )
 
 /**

--- a/hyphen/src/commonTest/kotlin/com/denser/hyphen/state/BlockManagerTest.kt
+++ b/hyphen/src/commonTest/kotlin/com/denser/hyphen/state/BlockManagerTest.kt
@@ -275,4 +275,50 @@ class BlockStyleManagerTest {
         }
         assertEquals("- [x] Task", state.text.toString())
     }
+
+    // --- Indented List Item Tests ---
+    @Test
+    fun `hasBlockStyle detects indented block styles`() {
+        val text = "  - Indented item 1\n    1. Indented item 2"
+
+        assertTrue(BlockStyleManager.hasBlockStyle(text, TextRange(5), MarkupStyle.BulletList))
+        assertTrue(BlockStyleManager.hasBlockStyle(text, TextRange(25), MarkupStyle.OrderedList))
+    }
+
+    @Test
+    fun `handleSmartEnter preserves indentation for bullet list`() {
+        val state = HyphenTextState("  - First Item")
+
+        state.textFieldState.edit {
+            this.selection = TextRange(state.textFieldState.text.length)
+            val handled = BlockStyleManager.handleSmartEnter(state, this)
+            assertTrue(handled)
+        }
+
+        assertEquals("  - First Item\n  - ", state.textFieldState.text.toString())
+    }
+
+    @Test
+    fun `handleSmartEnter preserves indentation for ordered list`() {
+        val state = HyphenTextState("    1. First Subitem")
+
+        state.textFieldState.edit {
+            this.selection = TextRange(state.textFieldState.text.length)
+            val handled = BlockStyleManager.handleSmartEnter(state, this)
+            assertTrue(handled)
+        }
+
+        assertEquals("    1. First Subitem\n    2. ", state.textFieldState.text.toString())
+    }
+
+    @Test
+    fun `applyBlockStyle preserves line indentation when toggling list`() {
+        val state = TextFieldState("  Some indented text")
+
+        state.edit {
+            BlockStyleManager.applyBlockStyle(this, emptyList(), TextRange(5), MarkupStyle.BulletList)
+        }
+
+        assertEquals("  - Some indented text", state.text.toString())
+    }
 }

--- a/sample/shared/src/commonMain/kotlin/com/denser/hyphen/sample/shared/HyphenSampleApp.kt
+++ b/sample/shared/src/commonMain/kotlin/com/denser/hyphen/sample/shared/HyphenSampleApp.kt
@@ -78,16 +78,15 @@ fun HyphenSampleApp(
     context: Any? = null,
 ) {
     val isAndroid = context != null
-    val editorState = rememberHyphenTextState(initialText = "")
-    
-    LaunchedEffect(Unit) {
-        editorState.triggerConfigs = listOf(
+    val triggerConfigs = remember {
+        listOf(
             TriggerConfig(trigger = "@", scheme = "user"),
             TriggerConfig(trigger = "#", scheme = "tag"),
             TriggerConfig(trigger = "{", scheme = "var", endTrigger = "}", addSpaceOnCompletion = false),
             TriggerConfig(trigger = "{{", scheme = "var", endTrigger = "}}", addSpaceOnCompletion = false)
         )
     }
+    val editorState = rememberHyphenTextState(initialText = "", triggerConfigs = triggerConfigs)
 
     val snackbarHostState = remember { SnackbarHostState() }
     var isDarkTheme by remember { mutableStateOf(false) }
@@ -364,5 +363,5 @@ private val DEMO_TEXT = """
     - [ ] Checklist task 1
     - [x] Checklist task 2
 
-    @Alice #tag {variable}
+    [@Alice](user:Alice) [#tag](tag:tag) [{variable}](var:variable)
 """.trimIndent()


### PR DESCRIPTION
## Overview
This PR introduces support for **Indented Lists** across all list types (checklists, bullet lists, and ordered lists) in the Hyphen editor, ensuring seamless multi-level list formatting and indentation controls.

## Key Features
- **Indented List Formatting**: Enables `Tab` and `Shift`+`Tab` indentation for ordered, unordered (bullet), and checklist block styles.
- **Smart Enter Continuation**: Extends smart enter detection to preserve indentation depth and automatically continue list prefixes on new lines.
- **Checkbox Overlay Alignment**: Synchronizes checkbox UI overlays with text indentation so interactive elements scale correctly across nested list levels.
- **Configurable Indent Width**: Adds `indentSpaces` configuration to `HyphenStyleConfig` to allow custom tab indentation spacing.

**Closes: #11**